### PR TITLE
vast.ai fix | "No devices were found" fallback for GPU_SELECT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ else
   export GPU_SELECT="$(nvidia-smi --query-gpu=uuid --format=csv,noheader | head -n1)"
 fi
 
-if [ -z "${GPU_SELECT}" ]; then
+if [ -z "${GPU_SELECT}" ] || [[ "${GPU_SELECT}" == "No devices were found" ]]; then
   export GPU_SELECT="$(nvidia-smi --query-gpu=uuid --format=csv,noheader | head -n1)"
   if [ -z "${GPU_SELECT}" ]; then
     echo "No NVIDIA GPUs detected or NVIDIA Container Toolkit not configured. Exiting."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ else
   export GPU_SELECT="$(nvidia-smi --query-gpu=uuid --format=csv,noheader | head -n1)"
 fi
 
-if [ -z "${GPU_SELECT}" ] || [[ "${GPU_SELECT}" == "No devices were found" ]]; then
+if [ -z "${GPU_SELECT}" ] || [ "${GPU_SELECT#*No devices}" != "${GPU_SELECT}" ]; then
   export GPU_SELECT="$(nvidia-smi --query-gpu=uuid --format=csv,noheader | head -n1)"
   if [ -z "${GPU_SELECT}" ]; then
     echo "No NVIDIA GPUs detected or NVIDIA Container Toolkit not configured. Exiting."


### PR DESCRIPTION
See discord help post: [https://discord.com/channels/798699922223398942/1409198002425561212](url)

Some users had problems to running glx on vast.ai / podman and get the error:
`/etc/entrypoint.sh: line 117: printf: 0x: invalid hex number
/etc/entrypoint.sh: line 117: printf: Option: invalid number
/etc/entrypoint.sh: line 117: printf: devices: invalid number
/etc/entrypoint.sh: line 117: printf: is: invalid number
/etc/entrypoint.sh: line 117: printf: not: invalid number
/etc/entrypoint.sh: line 117: printf: recognized: invalid number
/etc/entrypoint.sh: line 117: printf: 0xERROR: invalid hex number`

For some reason (Im not experienced enough to find out why), when the entrypoint.sh runs on start "NVIDIA_VISIBLE_DEVICES" is "1". If you echo NVIDIA_VISIBLE_DEVICES in the container its "all".

So when the entrypoint.sh is running, line 91: `if [ "${NVIDIA_VISIBLE_DEVICES}" != "all" ] && [ "${NVIDIA_VISIBLE_DEVICES}" != "none" ] && [ "${NVIDIA_VISIBLE_DEVICES}" != "void" ] && [ -n "${NVIDIA_VISIBLE_DEVICES}" ]; then` is true and runs:
`export GPU_SELECT="$(nvidia-smi --id=$(echo ${NVIDIA_VISIBLE_DEVICES} | cut -d ',' -f1) --query-gpu=uuid --format=csv,noheader | head -n1)"`
but if you add a echo here the result is "No devices were found".


On line 97 you have a fallback: `if [ -z "${GPU_SELECT}" ]; then`, but GPU_SELECT is a string with "No devices were found".

If you check for "No devices were found" as well he will run `export GPU_SELECT="$(nvidia-smi --query-gpu=uuid --format=csv,noheader | head -n1)"` and everything work.

I tested this on 10 different machines on vast.ai and everything worked.
But maybe this collapse with if no graphic card is available? 
